### PR TITLE
Fixed a bug preventing the navbar margin from being applied

### DIFF
--- a/public/stylesheets/default.css
+++ b/public/stylesheets/default.css
@@ -83,7 +83,7 @@ nav {
 .valueBox {
   color: green;
   font-weight: bold; 
-
+}
 .navbar-nav > li{
   margin-left:20px;
   margin-right:20px;


### PR DESCRIPTION
A missing brace in the default.css file prevented the margin from being applied as reported in issue #37 .