### PR TITLE
added configurable instance registry uri

### DIFF
--- a/app/controllers/InstanceRegistryController.scala
+++ b/app/controllers/InstanceRegistryController.scala
@@ -20,11 +20,13 @@ package controllers
 
 import akka.actor.ActorSystem
 import javax.inject.Inject
+import play.api.Configuration
 
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.ExecutionContext
 import play.api.libs.concurrent.CustomExecutionContext
-import play.api.libs.ws.{WSClient}
+import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
 
 trait MyExecutionContext extends ExecutionContext
 
@@ -44,11 +46,12 @@ class MyExecutionContextImpl @Inject()(system: ActorSystem)
   */
 class InstanceRegistryController @Inject()(myExecutionContext: MyExecutionContext,
                                            val controllerComponents: ControllerComponents,
-                                           ws: WSClient)
+                                           ws: WSClient, config: Configuration)
   extends BaseController {
-
+  val instanceRegistryUri = config.get[String]("app.instanceRegistryUri")
   def instances(componentType: String): Action[AnyContent] = Action.async {
-    ws.url("http://localhost:8087/instances").addQueryStringParameters("ComponentType" -> componentType).get().map { response =>
+
+    ws.url(instanceRegistryUri + "/instances").addQueryStringParameters("ComponentType" -> componentType).get().map { response =>
       // TODO: possible handling of parsing the data can be done here
 
       Ok(response.body)
@@ -58,7 +61,7 @@ class InstanceRegistryController @Inject()(myExecutionContext: MyExecutionContex
   def numberOfInstances(componentType: String) : Action[AnyContent] = Action.async {
     // TODO: handle what should happen if the instance registry is not reachable.
     // TODO: create constants for the urls
-    ws.url("http://localhost:8087/numberOfInstances").addQueryStringParameters("ComponentType" -> componentType).get().map { response =>
+    ws.url(instanceRegistryUri + "/numberOfInstances").addQueryStringParameters("ComponentType" -> componentType).get().map { response =>
       // TODO: possible handling of parsing the data can be done here
       if (response.status == 200) {
         Ok(response.body)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -365,5 +365,8 @@ play.modules.enabled += "module.Module"
 # play.http.errorHandler = "utils.ErrorHandler"
 
 app.portManagement = 8083
+app.instanceRegistryUri = "http://localhost:8087"
+app.instanceRegistryUri = ${?INSTANCE_REGISTRY_URI}
+
 
 include "silhouette.conf"


### PR DESCRIPTION
In this pull request the possibility to configure the location of the instance registry through an environment variable is given.

@bhermann is it necessary to verify if the content of the environment variable is a valid url, or to perform some additional checks on the variables content, since it is an input received from the outside? This could be done in a designated config loader (https://www.playframework.com/documentation/2.6.x/ScalaConfig) if needed. I could add this to the pull request if we want to have something like this.