### PR TITLE
Post request with params 

### DIFF
--- a/app/controllers/ApiRouter.scala
+++ b/app/controllers/ApiRouter.scala
@@ -36,13 +36,12 @@ class ApiRouter @Inject()(irController: InstanceRegistryController, sysControlle
     case GET(p"/numberOfInstances" ? q"componentType=$componentType") => irController.numberOfInstances(componentType)
     case GET(p"/instances" ? q"componentType=$componentType") => irController.instances(componentType)
     case GET(p"/systemInfo") => sysController.getInfo()
-    case POST(p"/postInstance") => irController.postInstance()
-    case POST(p"/startInstance") => irController.handleRequest(action="/start")
-    case POST(p"/stopInstance") => irController.handleRequest(action="/stop")
-    case POST(p"/pauseInstance") => irController.handleRequest(action="/pause")
-    case POST(p"/resumeInstance") => irController.handleRequest(action="/resume")
-    case POST(p"/deleteInstance") => irController.handleRequest(action="/delete")
-   
+    case POST(p"/postInstance" ? q"componentType=$componentType"& q"name=$name") => irController.postInstance(componentType, name)
+    case POST(p"/startInstance" ? q"instanceID=$instanceID") => irController.handleRequest(action="/start", instanceID)
+    case POST(p"/stopInstance" ? q"instanceID=$instanceID") => irController.handleRequest(action="/stop", instanceID)
+    case POST(p"/pauseInstance" ? q"instanceID=$instanceID") => irController.handleRequest(action="/pause", instanceID)
+    case POST(p"/resumeInstance" ? q"instanceID=$instanceID") => irController.handleRequest(action="/resume", instanceID)
+    case POST(p"/deleteInstance" ? q"instanceID=$instanceID") => irController.handleRequest(action="/delete", instanceID)
 
   }
 }

--- a/app/controllers/InstanceRegistryController.scala
+++ b/app/controllers/InstanceRegistryController.scala
@@ -101,18 +101,7 @@ class InstanceRegistryController @Inject()(implicit system: ActorSystem, mat: Ma
   */
 
 
-  def handleRequest(action: String): Action[AnyContent] = Action.async { request =>
-    var instanceID = ""
-    request.body.asJson.map { json =>
-      for (jsonValue <- (json \ "params" \ "updates").as[JsValue].as[Seq[JsValue]]
-      ) {
-        val obj = jsonValue.as[JsObject]
-        if ((obj \ "param").asOpt[String].get.equals("InstanceID")) {
-          instanceID = (obj \ "value").asOpt[String].get.substring(1)
-        }
-      }
-    }
-
+  def handleRequest(action: String, instanceID: String): Action[AnyContent] = Action.async { request =>
     ws.url(instanceRegistryUri + action)
       .addQueryStringParameters("Id" -> instanceID)
       .post("")
@@ -132,23 +121,7 @@ class InstanceRegistryController @Inject()(implicit system: ActorSystem, mat: Ma
   * @param componentType
   * @param name
   */
-  def postInstance(): Action[AnyContent] = Action.async { request =>
-    var compType = ""
-    var name = ""
-
-    request.body.asJson.map { json =>
-      for (jsonValue <- (json \ "params" \ "updates").as[JsValue].as[Seq[JsValue]]
-      ) {
-        val obj = jsonValue.as[JsObject]
-        if ((obj \ "param").asOpt[String].get.equals("componentType")) {
-          compType = (obj \ "value").asOpt[String].get
-        } else if ((obj \ "param").asOpt[String].get.equals("name")) {
-          name = (obj \ "value").asOpt[String].get
-        }
-      }
-
-    }
-
+  def postInstance(compType: String, name: String): Action[AnyContent] = Action.async { request =>
     ws.url(instanceRegistryUri + "/deploy")
       .addQueryStringParameters("ComponentType" -> compType, "InstanceName" -> name)
       .post("")

--- a/client/src/app/api/api/api.service.ts
+++ b/client/src/app/api/api/api.service.ts
@@ -17,7 +17,7 @@
  */
 
 import { Inject, Injectable, Optional } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Configuration } from '../configuration';
 import {
@@ -81,7 +81,8 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public getNumberOfInstances(componentType: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public getNumberOfInstances(componentType: string, observe: any = 'body', reportProgress: boolean = false):
+   Observable<HttpEvent<number>> {
     return this.get(NUMBER_OF_INSTANCES, componentType);
   }
 
@@ -114,7 +115,7 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public startInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public startInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<HttpEvent<number>> {
     return this.postAction(START_INSTANCE, instanceId);
   }
 
@@ -124,7 +125,7 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public stopInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public stopInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<HttpEvent<number>> {
     return this.postAction(STOP_INSTANCE, instanceId);
   }
 
@@ -134,7 +135,7 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public pauseInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public pauseInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<HttpEvent<number>> {
     return this.postAction(PAUSE_INSTANCE, instanceId);
   }
 
@@ -144,7 +145,7 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public resumeInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public resumeInstance(instanceId: string, observe: any = 'body', reportProgress: boolean = false): Observable<HttpEvent<number>> {
     return this.postAction(RESUME_INSTANCE, instanceId);
   }
 
@@ -154,7 +155,7 @@ export class ApiService {
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
-  public deleteInstance(instanceId: string): Observable<number> {
+  public deleteInstance(instanceId: string): Observable<HttpEvent<number>> {
     return this.postAction(DELETE_INSTANCE, instanceId);
   }
 
@@ -212,7 +213,7 @@ export class ApiService {
       headers = headers.set('Accept', httpHeaderAcceptSelected);
     }
 
-    return this.httpClient.post<Instance>(`${this.basePath}${endpoint}`,
+    return this.httpClient.post<Instance>(`${this.basePath}${endpoint}`, {},
       {
         params: queryParameters,
         withCredentials: this.configuration.withCredentials,
@@ -224,13 +225,14 @@ export class ApiService {
   }
 
 
-  public postAction(endpoint: string, idInstance: string, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public postAction(endpoint: string, idInstance: string, observe: any = 'body', reportProgress: boolean = false):
+    Observable<HttpEvent<number>> {
     let queryParam = new HttpParams({ encoder: new CustomHttpUrlEncodingCodec() });
 
     if (idInstance === null || idInstance === undefined) {
       throw new Error('Required ID Instance parameter');
     } else {
-      queryParam = queryParam.set('InstanceID', <any>('a' + idInstance));
+      queryParam = queryParam.set('instanceID', <any>('a' + idInstance));
     }
 
     return this.commonConf(endpoint, queryParam, observe, reportProgress);
@@ -238,7 +240,8 @@ export class ApiService {
 
 
   // This method is a common configuration to set the headers and query params
-  public commonConf(endpoint: string, queryParameters: HttpParams, observe: any = 'body', reportProgress: boolean = false): Observable<number> {
+  public commonConf(endpoint: string, queryParameters: HttpParams, observe: any = 'body', reportProgress: boolean = false):
+  Observable<HttpEvent<number>> {
     let headers = this.defaultHeaders;
 
     // to determine the Accept header
@@ -251,7 +254,7 @@ export class ApiService {
       headers = headers.set('Accept', httpHeaderAcceptSelected);
     }
 
-    return this.httpClient.post<number>(`${this.basePath}${endpoint}`,
+    return this.httpClient.post<number>(`${this.basePath}${endpoint}`, {},
       {
         params: queryParameters,
         withCredentials: this.configuration.withCredentials,

--- a/client/src/app/dashboard/dashboard-card/dashboard-card.component.ts
+++ b/client/src/app/dashboard/dashboard-card/dashboard-card.component.ts
@@ -21,6 +21,7 @@ import {EventType, EventTypeEnum} from '../../api/model/socketMessage';
 import {ComponentType, ComponentTypeEnum} from '../../api/model/instance';
 import {ApiService} from '../../api/api/api.service';
 import {SocketService} from '../../api/api/socket.service';
+import { HttpEvent } from '@angular/common/http';
 
 
 
@@ -83,7 +84,7 @@ export class DashboardCardComponent implements OnInit {
    * If there is no server connection the value is set to a default error message.
    */
   private setInstanceNumber() {
-    this.irService.getNumberOfInstances(this.componentType).subscribe((amount: number) => {
+    this.irService.getNumberOfInstances(this.componentType).subscribe((amount: HttpEvent<number>) => {
       this.numberOfInstances = '' + amount;
     }, () => {
       this.numberOfInstances = 'No server connection';

--- a/client/src/app/dashboard/table-all/table-all.component.ts
+++ b/client/src/app/dashboard/table-all/table-all.component.ts
@@ -22,6 +22,7 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatTable, MatPaginator, MatTa
 import { DeleteDialogComponent } from '../delete-dialog/delete-dialog.component';
 import { AddDialogComponent } from '../add-dialog/add-dialog.component';
 import { ApiService } from '../../api/api/api.service';
+import { HttpEvent } from '@angular/common/http';
 
 
 
@@ -77,7 +78,7 @@ export class TableAllComponent implements OnInit {
                 console.log('data', this.dataSource.data);
 
             } else {
-                this.apiService.deleteInstance(id).subscribe((deleteResult: number) => {
+                this.apiService.deleteInstance(id).subscribe((deleteResult: HttpEvent<number>) => {
                     console.log('result', deleteResult);
                 }, err => {
                     console.log('error delete Instance');
@@ -133,7 +134,7 @@ export class TableAllComponent implements OnInit {
    */
     public startInstance(id: string): void {
 
-        this.apiService.startInstance(id).subscribe((result: number) => {
+        this.apiService.startInstance(id).subscribe((result: HttpEvent<number>) => {
             console.log('result', result);
         }, err => {
             console.log('error start Instance', err);
@@ -146,7 +147,7 @@ export class TableAllComponent implements OnInit {
    */
     public stopInstance(id: string): void {
 
-        this.apiService.stopInstance(id).subscribe((result: number) => {
+        this.apiService.stopInstance(id).subscribe((result: HttpEvent<number>) => {
             console.log('result', result);
         }, err => {
             console.log('error stop Instance', err);
@@ -159,7 +160,7 @@ export class TableAllComponent implements OnInit {
    */
     public pauseInstance(id: string): void {
 
-        this.apiService.pauseInstance(id).subscribe((result: number) => {
+        this.apiService.pauseInstance(id).subscribe((result: HttpEvent<number>) => {
             console.log('result', result);
         }, err => {
             console.log('error pause instance', err);
@@ -172,7 +173,7 @@ export class TableAllComponent implements OnInit {
    */
     public resumeInstance(id: string): void {
 
-        this.apiService.resumeInstance(id).subscribe((result: number) => {
+        this.apiService.resumeInstance(id).subscribe((result: HttpEvent<number>) => {
             console.log('result', result);
         }, err => {
             console.log('error pause instance', err);


### PR DESCRIPTION
implemented an example where the params of post request are actually send as params.
fixed a bug that the options of the http request where send as the body
feel free to merge this request in your branch or use the code anyway you see fit and close the pull request ;)

EDIT: this should also fix the forbidden access error you received before altering the crsf settings, since you never send http headers with the request before and send all options as the body of the request by mistake